### PR TITLE
Fixed Update methods and tests to use PUT verb in line with API

### DIFF
--- a/pointdns/base.py
+++ b/pointdns/base.py
@@ -47,7 +47,7 @@ class BaseMember(BaseResource):
 
     @BaseResource.validate
     def update(self, **kwargs):
-        response = self.request('post', kwargs)
+        response = self.request('put', kwargs)
         if response.status == 202:
             return
         if response.status == 422:

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -30,3 +30,29 @@ class RequestTests(unittest2.TestCase):
             r = request('get', '/', ('john', 'secret-key'), scheme='http')
             self.assertTrue(r.status == 200)
             self.assertTrue(r.content == 'OK')
+
+    def test_http_put_request(self):
+
+        @urlmatch(netloc=r'pointhq\.com', scheme='http',
+                  method='put', path='/')
+        def response_content(url, request):
+            return {'status_code': 200,
+                    'content': b'OK'}
+
+        with HTTMock(response_content):
+            r = request('put', '/', ('john', 'secret-key'), scheme='http')
+            self.assertTrue(r.status == 200)
+            self.assertTrue(r.content == 'OK')
+
+    def test_https_put_request(self):
+
+        @urlmatch(netloc=r'pointhq\.com', scheme='https',
+                  method='put', path='/')
+        def response_content(url, request):
+            return {'status_code': 200,
+                    'content': b'OK'}
+
+        with HTTMock(response_content):
+            r = request('put', '/', ('john', 'secret-key'), scheme='https')
+            self.assertTrue(r.status == 200)
+            self.assertTrue(r.content == 'OK')

--- a/tests/test_zone_records.py
+++ b/tests/test_zone_records.py
@@ -66,7 +66,7 @@ class ZoneRecordTests(unittest2.TestCase):
     def test_member_update(self):
         self.request.return_value = Response(202)
         self.assertIsNone(self.point.zones(1).records(1).update(data='123.45.67.89'))
-        self.request.assert_called_once_with('post', '/zones/1/records/1', self.auth, {
+        self.request.assert_called_once_with('put', '/zones/1/records/1', self.auth, {
             'zone_record': {
                 'data': '123.45.67.89',
             }

--- a/tests/test_zones.py
+++ b/tests/test_zones.py
@@ -71,7 +71,7 @@ class ZoneTests(unittest2.TestCase):
     def test_member_update(self):
         self.request.return_value = Response(202)
         self.assertIsNone(self.point.zones(1).update(group='clients'))
-        self.request.assert_called_once_with('post', '/zones/1', self.auth, {
+        self.request.assert_called_once_with('put', '/zones/1', self.auth, {
             'zone': {
                 'group': 'clients',
             }


### PR DESCRIPTION
I was getting 500 errors when calling update methods with this API. On inspection of the [API docs](https://pointhq.com/api/docs#zones-examples) I found the update methods use PUT for updates in line with a standard REST implementation.

I've updated the `update` method and respective tests.
